### PR TITLE
[Feature] Add local_space & global_space properties to Emitter type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -142,6 +142,7 @@ export class Emitter {
 	)
 	config: Config
 	local_space: Object3D
+	global_space: Object3D
 
 	/**
 	 * Delete the emitter

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -141,6 +141,8 @@ export class Emitter {
 		options?: EmitterOptions
 	)
 	config: Config
+	local_space: Object3D
+
 	/**
 	 * Delete the emitter
 	 */


### PR DESCRIPTION
## Motivation:
These properties should be exposed to implement particle effects bound to locators.