### PR TITLE
[Feature] Add Emitter.clone() method to Emitter type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -175,6 +175,11 @@ export class Emitter {
 	 * @param time Time in seconds
 	 */
 	jumpTo(time: number): Emitter
+
+	/**
+	 * Clone an emitter
+	 */
+	clone(): Emitter
 }
 
 export interface GlobalOptions {


### PR DESCRIPTION
## Motivation:
This method currently isn't exposed inside of the TypeScript declaration files.